### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -1,5 +1,9 @@
 name: Generate API Documentation
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/ZiProject/ZiPlayer/security/code-scanning/19](https://github.com/ZiProject/ZiPlayer/security/code-scanning/19)

To fix the problem, add a `permissions` block to the workflow, specifying only those permissions necessary for the steps in the job. Since this workflow pushes code changes (`contents: write`) and creates pull requests (`pull-requests: write`), those are the minimum required permissions. The block may be added at either the workflow level (before the `jobs:` key) so that it applies to all jobs, or inside the `generate-docs` job under jobs, but the general convention is to set workflow-level permissions for singleton jobs unless more granularity is needed. The change must be made in `.github/workflows/generate-api-docs.yml`, with no other files or code changes required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
