### PR TITLE
fix(queue): prevent anti-stuck skip loop

### DIFF
--- a/core/src/structures/Queue.ts
+++ b/core/src/structures/Queue.ts
@@ -221,6 +221,13 @@ export class Queue {
 			this.addToHistory(this.current);
 		}
 
+		// When bypassing a track loop, an anti-stuck retry may have reinserted
+		// the current track at the front of the queue. Consume that duplicate
+		// before selecting the real next track so a failed track cannot loop forever.
+		if (ignoreLoop && this.current && this.tracks[0] === this.current) {
+			this.tracks.shift();
+		}
+
 		// Get next track
 		this.current = this.tracks.shift() || null;
 


### PR DESCRIPTION
## Summary
- prevent a failed anti-stuck track from being selected again after `skipLoop` is set
- consume the reinserted current track before selecting the next track when loop bypass is requested

## Root cause
`Player.playNext()` re-inserts a failed track at queue index `0` during anti-stuck retries. When the controlled skip threshold is reached, it sets `skipLoop = true`, but `Queue.next(true)` previously only bypassed loop mode and still shifted that same reinserted track from the front of the queue.

This could produce an endless `STUCK -> skip -> STUCK` cycle on the same track.

## Fix
When `Queue.next(true)` is called and the first queued track is the exact current track, consume that reinserted duplicate before selecting the next track. Normal queue progression and manual skip behavior remain unchanged.

## Validation
- branch is based on `new-dowload`
- diff is limited to `core/src/structures/Queue.ts` (7 added lines)